### PR TITLE
adds Tagged interface for Gauge, Counter, Meter, etc

### DIFF
--- a/metrics-datadog/src/main/java/org/coursera/metrics/datadog/Tagged.java
+++ b/metrics-datadog/src/main/java/org/coursera/metrics/datadog/Tagged.java
@@ -1,16 +1,16 @@
 package org.coursera.metrics.datadog;
 
-import java.util.AbstractList;
+import java.util.List;
 
 /**
- * An interface to be implemented by Gauges which wish to expose additional
+ * An interface to be implemented by Gauges, Counter, etc which wish to expose additional
  * tags to datadog
  */
-public interface TaggedGauge {
+public interface Tagged {
 
     /**
      * Return a List of Strings to values for Datadog reporter to send along to datadog
      * with the metrics
      */
-    public AbstractList getTags();
+    public List<String> getTags();
 }


### PR DESCRIPTION
the when a Gauge, Counter, Meter, Timer or Histogram also
implements the Tagged interface then the getTags methods
of this metrics will be merged with tags from the reporter
before reporting upstream.

fixes #25
